### PR TITLE
Mobile styles

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,6 +32,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="stylesheet" href="bootstrap.min.css">
+  <link rel="stylesheet" href="styles.css">
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.0/jquery.min.js"></script>
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js"></script>
   <link href='https://fonts.googleapis.com/css?family=Oswald:700' rel='stylesheet' type='text/css'>
@@ -67,8 +68,8 @@
 
         <div class="row">
             <!-- Contact Info on the Sidebar -->
-            <div class="col-md-4">
-		    <div style="font-size:16px; margin-left:-7vh"">
+            <div class="col-sm-12">
+		    <div class="ContactInfoContainer">
                 <img class="img-responsive" src="headshot_jotte.jpg" alt="image of me" style="width:280px;height:225px;"><br>
                 <div style="font-family: 'Oswald', sans-serif; font-size: 30px;"><b>Amanda R. Kube Jotte, M.S., Ph.D.</b></div><br>
 		<div style="font-family: 'Oswald', sans-serif; font-size: 23px;"><b>Assistant Instructional Professor</b></div><br>
@@ -102,7 +103,7 @@
 
 
             <!-- Entries Column -->
-            <div class="col-md-8" style="height: 50vh; margin-right:-7vh">
+            <div class="col-12 col-md-8 EntriesColumn" >
                 
                 <div style="margin-top:3%; text-align:justify; font-size:20px; line-height:1.5">                
 					<p style="line-height:134%"> I am an Assistant Professor of Data Science at The University of Chicago's <a href="https://datascience.uchicago.edu/" target="_blank">Data Science Institute</a>. My current interests involve classroom action research on effective teaching strategies in data science as well as the development of best practices in teaching data science ethics. I am currently building a transferable data science curriculum for the City Colleges of Chicago as part of The University of Chicago’s Preceptorship Program and I am excited to continue contributing to the data science undergraduate major and new masters program at the University of Chicago. </p>

--- a/index.html
+++ b/index.html
@@ -6,128 +6,265 @@
 -->
 
 <html lang="en">
-
-<head>
+  <head>
     <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-172221298-1"></script>
+    <script
+      async
+      src="https://www.googletagmanager.com/gtag/js?id=UA-172221298-1"
+    ></script>
     <script>
       window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
+      function gtag() {
+        dataLayer.push(arguments);
+      }
+      gtag("js", new Date());
 
-      gtag('config', 'UA-172221298-1');
+      gtag("config", "UA-172221298-1");
     </script>
 
-    <meta charset="UTF-8">
-    <meta name="author" content="Amanda R. Kube Jotte">
-    <meta name="robots" content="INDEX,FOLLOW">
-    <meta name="keywords" content="Amanda, Kube, Jotte, PhD, Data Science, Computational Social Science">
-    <meta name="description"
-        content="Data Science Preceptor studying applications of AI to Social Sciences and Public Health">
-    <meta content="IE=edge" http-equiv="X-UA-Compatible">
+    <meta charset="UTF-8" />
+    <meta name="author" content="Amanda R. Kube Jotte" />
+    <meta name="robots" content="INDEX,FOLLOW" />
+    <meta
+      name="keywords"
+      content="Amanda, Kube, Jotte, PhD, Data Science, Computational Social Science"
+    />
+    <meta
+      name="description"
+      content="Data Science Preceptor studying applications of AI to Social Sciences and Public Health"
+    />
+    <meta content="IE=edge" http-equiv="X-UA-Compatible" />
     <meta name="google" content="notranslate" />
-    <meta name="google-site-verification" content="leIOIHzfotk4I-5IQ5_YwW-Ubl-t0JqtmYpaa6gzBJg" />
-	
-  <title>Amanda R. Kube Jotte</title>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link rel="stylesheet" href="bootstrap.min.css">
-  <link rel="stylesheet" href="styles.css">
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.0/jquery.min.js"></script>
-  <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js"></script>
-  <link href='https://fonts.googleapis.com/css?family=Oswald:700' rel='stylesheet' type='text/css'>
-</head>
-<body>
+    <meta
+      name="google-site-verification"
+      content="leIOIHzfotk4I-5IQ5_YwW-Ubl-t0JqtmYpaa6gzBJg"
+    />
 
+    <title>Amanda R. Kube Jotte</title>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="bootstrap.min.css" />
+    <link rel="stylesheet" href="styles.css" />
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.0/jquery.min.js"></script>
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js"></script>
+    <link
+      href="https://fonts.googleapis.com/css?family=Oswald:700"
+      rel="stylesheet"
+      type="text/css"
+    />
+  </head>
+  <body>
+    <!-- Navigation -->
+    <nav class="navbar navbar-inverse navbar-static-top" role="navigation">
+      <div class="container">
+        <div class="navbar-header">
+          <button
+            type="button"
+            class="navbar-toggle collapsed"
+            data-toggle="collapse"
+            data-target="#bs-example-navbar-collapse-1"
+          >
+            <span class="sr-only">Toggle navigation</span>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+          </button>
+        </div>
 
-<!-- Navigation -->
-	<nav class="navbar navbar-inverse navbar-static-top" role="navigation">
-	  <div class="container">
-		<div class="navbar-header">
-		  <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#bs-example-navbar-collapse-1">
-						<span class="sr-only">Toggle navigation</span>
-						<span class="icon-bar"></span>
-						<span class="icon-bar"></span>
-						<span class="icon-bar"></span>
-					</button>
-		</div>
+        <!-- Collect the nav links, forms, and other content for toggling -->
+        <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
+          <ul class="nav navbar-nav">
+            <li><a href="index.html" style="font-size: 20px">Home</a></li>
+            <li>
+              <a href="teaching.html" style="font-size: 20px">Teaching</a>
+            </li>
+            <li>
+              <a href="publications.html" style="font-size: 20px"
+                >Publications</a
+              >
+            </li>
+            <li>
+              <a
+                href="Amanda_Kube_CV_111423.pdf"
+                target="_blank"
+                style="font-size: 20px"
+                >CV</a
+              >
+            </li>
+          </ul>
+        </div>
+      </div>
+    </nav>
 
-		<!-- Collect the nav links, forms, and other content for toggling -->
-		<div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
-		  <ul class="nav navbar-nav">
-				  <li><a href="index.html" style="font-size: 20px;">Home</a></li>
-			  	<li><a href="teaching.html" style="font-size: 20px;">Teaching</a></li>
-			  	<li><a href="publications.html" style="font-size: 20px;">Publications</a></li>
-				  <li><a href="Amanda_Kube_CV_111423.pdf" target="_blank" style="font-size: 20px;">CV</a></li> 
-		  </ul>
-		</div>
-	  </div>
-	</nav>
-  
     <div class="container">
-
-        <div class="row">
-            <!-- Contact Info on the Sidebar -->
-            <div class="col-sm-12">
-		    <div class="ContactInfoContainer">
-                <img class="img-responsive" src="headshot_jotte.jpg" alt="image of me" style="width:280px;height:225px;"><br>
-                <div style="font-family: 'Oswald', sans-serif; font-size: 30px;"><b>Amanda R. Kube Jotte, M.S., Ph.D.</b></div><br>
-		<div style="font-family: 'Oswald', sans-serif; font-size: 23px;"><b>Assistant Instructional Professor</b></div><br>
-                <p><b>akube@uchicago.edu</b><br>
-                <p>Data Science Institute<br>
-                The University of Chicago<br>
-                </p>
-			    <a href="https://twitter.com/AmandaRKube"
-                                        title=""><img alt="twitter" target="_blank"
-                                            src="twitter.png" style="width:32px;height:32px;"></a>
-		   
-		    <a href="https://www.linkedin.com/in/amanda-kube-488071a8/"
-                                        title=""><img alt="linkedin" target="_blank"
-                                            src="linkedin.png" style="width:32px;height:32px;"></a>
-					
-		    <a href="https://scholar.google.com/citations?user=eML9qi8AAAAJ&hl=en&inst=2230987035966559800"
-                                        title=""><img alt="Google Scholar" target="_blank"
-                                            src="google-scholar.svg" style="width:32px;height:32px;"></a>
-					
-		    <a href="https://www.researchgate.net/profile/Amanda_Kube?cp=shp"
-                                        title=""><img alt="Follow me on ResearchGate" target="_blank"
-                                            src="researchgate.svg" style="width:32px;height:32px;"></a>
-					
-		    <a href="https://orcid.org/0000-0002-4814-3209"
-                                        title=""><img alt="orcid" target="_blank"
-							   src="orcid.svg" style="width:32px;height:32px;"></a>
+      <div class="row">
+        <!-- Contact Info on the Sidebar -->
+        <div class="col-sm-12 col-md-4">
+          <div class="ContactInfoContainer">
+            <img
+              class="img-responsive Headshot"
+              src="headshot_jotte.jpg"
+              alt="image of me"
+            /><br />
+            <div class="ContactInfoTextMain NameAndTitles">
+              <b>Amanda R. Kube Jotte, M.S., Ph.D.</b>
             </div>
-		    </div>
-	
-	<!-- Page Content -->
-
-
-            <!-- Entries Column -->
-            <div class="col-12 col-md-8 EntriesColumn" >
-                
-                <div style="margin-top:3%; text-align:justify; font-size:20px; line-height:1.5">                
-					<p style="line-height:134%"> I am an Assistant Professor of Data Science at The University of Chicago's <a href="https://datascience.uchicago.edu/" target="_blank">Data Science Institute</a>. My current interests involve classroom action research on effective teaching strategies in data science as well as the development of best practices in teaching data science ethics. I am currently building a transferable data science curriculum for the City Colleges of Chicago as part of The University of Chicago’s Preceptorship Program and I am excited to continue contributing to the data science undergraduate major and new masters program at the University of Chicago. </p>
-						
-			<p style="line-height:134%"> Before coming to the University of Chicago I attended Washington University in St. Louis where I received a double major in mathematics and psychology, graduating summa cum laude and as a member of the Phi Beta Kappa honor society. I earned my doctorate in <a href="https://datasciences.wustl.edu/" target="_blank">Computational and Data Sciences</a> from Washington University in St. Louis as the pioneering graduate of the program, where I studied applications of machine learning and AI for scarce resource allocation in the context of homelessness prevention services. I was advised by <a href="https://cs.gmu.edu/~sanmay/" target="_blank">Dr. Sanmay Das</a>&nbsp; at George Mason University and <a href="https://brownschool.wustl.edu/Faculty-and-Research/Pages/Patrick-Fowler.aspx" target="_blank">Dr. Patrick Fowler</a> in the Division of Computational and Data Sciences at Washington University in St. Louis. </p>
-					  </div>
-		    <div style="margin-top:10%; text-align:justify; font-size:20px; line-height:1.5">  
-		    <h2 id="news">News</h2>
-		    <ul>
-			<li>April 2024: Looking forward to starting my new position as Assistant Instructional Professor at the University of Chicago Data Science Institute.</li>
-			<li>October 2023: Thrilled to be presenting at ADSA this year in San Antonio! Looking forward to discussing data science education with so many wonderful instructors.</li>
-			<li>April 2023: Excited to announce our paper <i>Fair and Efficient Allocation of Scarce Resources Based on Predicted Outcomes: Implications for Homeless Service Delivery</i> is officially published and available <a
-                                        href="https://jair.org/index.php/jair/article/view/12847" target="_blank">here</a> </li>
-			<li>June 2022: I am now officially a Preceptor at UChicago's DSI - excited to welcome our Summer Lab students!</li>
-			<li>April 2022: I successfully defended my dissertation!</li>
-  			<li>February 2022: I accepted a position at the University of Chicago to begin June 2022</li>
-		    </ul>
-            </div> 
-		</div>
+            <br />
+            <div class="ContactInfoTextMain CurrentPosition">
+              <b>Assistant Instructional Professor</b>
             </div>
-	    </div>
+            <br />
+            <p><b>akube@uchicago.edu</b><br /></p>
+            <p>
+              Data Science Institute<br />
+              The University of Chicago<br />
+            </p>
+            <a href="https://twitter.com/AmandaRKube" title=""
+              ><img
+                alt="twitter"
+                target="_blank"
+                src="twitter.png"
+                class="SocialIcon"
+            /></a>
 
-    
-     
-</body>
+            <a href="https://www.linkedin.com/in/amanda-kube-488071a8/" title=""
+              ><img
+                alt="linkedin"
+                target="_blank"
+                src="linkedin.png"
+                class="SocialIcon"
+            /></a>
 
+            <a
+              href="https://scholar.google.com/citations?user=eML9qi8AAAAJ&hl=en&inst=2230987035966559800"
+              title=""
+              ><img
+                alt="Google Scholar"
+                target="_blank"
+                src="google-scholar.svg"
+                class="SocialIcon"
+            /></a>
+
+            <a
+              href="https://www.researchgate.net/profile/Amanda_Kube?cp=shp"
+              title=""
+              ><img
+                alt="Follow me on ResearchGate"
+                target="_blank"
+                src="researchgate.svg"
+                class="SocialIcon"
+            /></a>
+
+            <a href="https://orcid.org/0000-0002-4814-3209" title=""
+              ><img
+                alt="orcid"
+                target="_blank"
+                src="orcid.svg"
+                class="SocialIcon"
+            /></a>
+          </div>
+        </div>
+
+        <!-- Page Content -->
+
+        <!-- Entries Column -->
+        <div class="col-sm-12 col-md-8 EntriesColumn">
+          <div
+            style="
+              margin-top: 3%;
+              text-align: justify;
+              font-size: 20px;
+              line-height: 1.5;
+              line-height: 134%;
+            "
+          >
+            <p>
+              I am an Assistant Professor of Data Science at The University of
+              Chicago's
+              <a href="https://datascience.uchicago.edu/" target="_blank"
+                >Data Science Institute</a
+              >. My current interests involve classroom action research on
+              effective teaching strategies in data science as well as the
+              development of best practices in teaching data science ethics. I
+              am currently building a transferable data science curriculum for
+              the City Colleges of Chicago as part of The University of
+              Chicago’s Preceptorship Program and I am excited to continue
+              contributing to the data science undergraduate major and new
+              masters program at the University of Chicago.
+            </p>
+
+            <p>
+              Before coming to the University of Chicago I attended Washington
+              University in St. Louis where I received a double major in
+              mathematics and psychology, graduating summa cum laude and as a
+              member of the Phi Beta Kappa honor society. I earned my doctorate
+              in
+              <a href="https://datasciences.wustl.edu/" target="_blank"
+                >Computational and Data Sciences</a
+              >
+              from Washington University in St. Louis as the pioneering graduate
+              of the program, where I studied applications of machine learning
+              and AI for scarce resource allocation in the context of
+              homelessness prevention services. I was advised by
+              <a href="https://cs.gmu.edu/~sanmay/" target="_blank"
+                >Dr. Sanmay Das</a
+              >&nbsp; at George Mason University and
+              <a
+                href="https://brownschool.wustl.edu/Faculty-and-Research/Pages/Patrick-Fowler.aspx"
+                target="_blank"
+                >Dr. Patrick Fowler</a
+              >
+              in the Division of Computational and Data Sciences at Washington
+              University in St. Louis.
+            </p>
+          </div>
+          <div
+            style="
+              margin-top: 10%;
+              text-align: justify;
+              font-size: 20px;
+              line-height: 1.5;
+            "
+          >
+            <h2 id="news">News</h2>
+            <ul>
+              <li>
+                April 2024: Looking forward to starting my new position as
+                Assistant Instructional Professor at the University of Chicago
+                Data Science Institute.
+              </li>
+              <li>
+                October 2023: Thrilled to be presenting at ADSA this year in San
+                Antonio! Looking forward to discussing data science education
+                with so many wonderful instructors.
+              </li>
+              <li>
+                April 2023: Excited to announce our paper
+                <i
+                  >Fair and Efficient Allocation of Scarce Resources Based on
+                  Predicted Outcomes: Implications for Homeless Service
+                  Delivery</i
+                >
+                is officially published and available
+                <a
+                  href="https://jair.org/index.php/jair/article/view/12847"
+                  target="_blank"
+                  >here</a
+                >
+              </li>
+              <li>
+                June 2022: I am now officially a Preceptor at UChicago's DSI -
+                excited to welcome our Summer Lab students!
+              </li>
+              <li>April 2022: I successfully defended my dissertation!</li>
+              <li>
+                February 2022: I accepted a position at the University of
+                Chicago to begin June 2022
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </div>
+  </body>
 </html>

--- a/publications.html
+++ b/publications.html
@@ -6,143 +6,276 @@
 -->
 
 <html lang="en">
-
-<head>
+  <head>
     <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-172221298-1"></script>
+    <script
+      async
+      src="https://www.googletagmanager.com/gtag/js?id=UA-172221298-1"
+    ></script>
     <script>
       window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
+      function gtag() {
+        dataLayer.push(arguments);
+      }
+      gtag("js", new Date());
 
-      gtag('config', 'UA-172221298-1');
+      gtag("config", "UA-172221298-1");
     </script>
 
-    <meta charset="UTF-8">
-    <meta name="author" content="Amanda R. Kube Jotte">
-    <meta name="robots" content="INDEX,FOLLOW">
-    <meta name="keywords" content="Amanda, Kube, Jotte, PhD, Data Science, Computational Social Science">
-    <meta name="description"
-        content="Data Science Preceptor studying applications of AI to Social Sciences and Public Health">
-    <meta content="IE=edge" http-equiv="X-UA-Compatible">
-    <meta content="width=device-width,initial-scale=1" name="viewport">
+    <meta charset="UTF-8" />
+    <meta name="author" content="Amanda R. Kube Jotte" />
+    <meta name="robots" content="INDEX,FOLLOW" />
+    <meta
+      name="keywords"
+      content="Amanda, Kube, Jotte, PhD, Data Science, Computational Social Science"
+    />
+    <meta
+      name="description"
+      content="Data Science Preceptor studying applications of AI to Social Sciences and Public Health"
+    />
+    <meta content="IE=edge" http-equiv="X-UA-Compatible" />
+    <meta content="width=device-width,initial-scale=1" name="viewport" />
     <meta name="google" content="notranslate" />
-    <meta name="google-site-verification" content="leIOIHzfotk4I-5IQ5_YwW-Ubl-t0JqtmYpaa6gzBJg" />
-	
-  <title>Amanda R. Kube Jotte Publications</title>
-  <meta charset="utf-8">
-  <meta name="HandheldFriendly" content="True">
-	<meta name="MobileOptimized" content="320">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link rel="stylesheet" href="bootstrap.min.css">
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.0/jquery.min.js"></script>
-  <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js"></script>
-  <link href='https://fonts.googleapis.com/css?family=Oswald:700' rel='stylesheet' type='text/css'>
-</head>
-<body>
+    <meta
+      name="google-site-verification"
+      content="leIOIHzfotk4I-5IQ5_YwW-Ubl-t0JqtmYpaa6gzBJg"
+    />
 
+    <title>Amanda R. Kube Jotte Publications</title>
+    <meta charset="utf-8" />
+    <meta name="HandheldFriendly" content="True" />
+    <meta name="MobileOptimized" content="320" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="bootstrap.min.css" />
+    <link rel="stylesheet" href="styles.css" />
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.0/jquery.min.js"></script>
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js"></script>
+    <link
+      href="https://fonts.googleapis.com/css?family=Oswald:700"
+      rel="stylesheet"
+      type="text/css"
+    />
+  </head>
+  <body>
+    <!-- Navigation -->
+    <nav class="navbar navbar-inverse navbar-static-top" role="navigation">
+      <div class="container">
+        <div class="navbar-header">
+          <button
+            type="button"
+            class="navbar-toggle collapsed"
+            data-toggle="collapse"
+            data-target="#bs-example-navbar-collapse-1"
+          >
+            <span class="sr-only">Toggle navigation</span>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+          </button>
+        </div>
 
-<!-- Navigation -->
-	<nav class="navbar navbar-inverse navbar-static-top" role="navigation">
-	  <div class="container">
-		<div class="navbar-header">
-		  <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#bs-example-navbar-collapse-1">
-						<span class="sr-only">Toggle navigation</span>
-						<span class="icon-bar"></span>
-						<span class="icon-bar"></span>
-						<span class="icon-bar"></span>
-					</button>
-		</div>
+        <!-- Collect the nav links, forms, and other content for toggling -->
+        <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
+          <ul class="nav navbar-nav">
+            <li><a href="index.html" style="font-size: 20px">Home</a></li>
+            <li>
+              <a href="teaching.html" style="font-size: 20px">Teaching</a>
+            </li>
+            <li>
+              <a href="publications.html" style="font-size: 20px"
+                >Publications</a
+              >
+            </li>
+            <li>
+              <a
+                href="Amanda_Kube_CV_111423.pdf"
+                target="_blank"
+                style="font-size: 20px"
+                >CV</a
+              >
+            </li>
+          </ul>
+        </div>
+      </div>
+    </nav>
 
-		<!-- Collect the nav links, forms, and other content for toggling -->
-		<div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
-		  <ul class="nav navbar-nav">
-				  <li><a href="index.html" style="font-size: 20px;">Home</a></li>
-			  	<li><a href="teaching.html" style="font-size: 20px;">Teaching</a></li>
-			  	<li><a href="publications.html" style="font-size: 20px;">Publications</a></li>
-				  <li><a href="Amanda_Kube_CV_111423.pdf" target="_blank" style="font-size: 20px;">CV</a></li> 
-		  </ul>
-		</div>
-	  </div>
-	</nav>
-  
     <div class="container">
-
-        <div class="row">
-            <!-- Contact Info on the Sidebar -->
-            <div class="col-md-4">
-		    <div style="font-size:16px; margin-left:-60px">
-                <img class="img-responsive" src="headshot_jotte.jpg" alt="image of me" style="width:280px;height:225px;"><br>
-                <div style="font-family: 'Oswald', sans-serif; font-size: 30px;"><b>Amanda R. Kube Jotte, M.S., Ph.D.</b></div><br>
-		<div style="font-family: 'Oswald', sans-serif; font-size: 23px;"><b>Assistant Instructional Professor</b></div><br>
-                <p><b>akube@uchicago.edu</b><br>
-                <p>Data Science Institute<br>
-                The University of Chicago<br>
-                </p>
-			    <a href="https://twitter.com/AmandaRKube"
-                                        title=""><img alt="twitter" target="_blank"
-                                            src="twitter.png" style="width:32px;height:32px;"></a>
-		   
-		    <a href="https://www.linkedin.com/in/amanda-kube-488071a8/"
-                                        title=""><img alt="linkedin" target="_blank"
-                                            src="linkedin.png" style="width:32px;height:32px;"></a>
-					
-		    <a href="https://scholar.google.com/citations?user=eML9qi8AAAAJ&hl=en&inst=2230987035966559800"
-                                        title=""><img alt="Google Scholar" target="_blank"
-                                            src="google-scholar.svg" style="width:32px;height:32px;"></a>
-					
-		    <a href="https://www.researchgate.net/profile/Amanda_Kube?cp=shp"
-                                        title=""><img alt="Follow me on ResearchGate" target="_blank"
-                                            src="researchgate.svg" style="width:32px;height:32px;"></a>
-					
-		    <a href="https://orcid.org/0000-0002-4814-3209"
-                                        title=""><img alt="orcid" target="_blank"
-							   src="orcid.svg" style="width:32px;height:32px;"></a>
+      <div class="row">
+        <!-- Contact Info on the Sidebar -->
+        <div class="col-sm-12 col-md-4">
+          <div class="ContactInfoContainer">
+            <img
+              class="img-responsive Headshot"
+              src="headshot_jotte.jpg"
+              alt="image of me"
+            /><br />
+            <div class="ContactInfoTextMain NameAndTitles">
+              <b>Amanda R. Kube Jotte, M.S., Ph.D.</b>
             </div>
-		    </div>
-	
-	<!-- Page Content -->
-
-            <!-- Entries Column -->
-            <div class="col-md-8" style="height: 50vh;">
-                
-                <div style="margin-top:3%; font-size:20px; line-height:1.5; margin-bottom:3%; margin-right:-65px"> 
-                  <h2 id="teaching">Publications</h2>
-                  <ul>
-
-                  <li>Kaufmann, R., Harris, Bozer A., Jotte, A. R. K., Aqua, K., (2023) The Effects of Long-Term Self-Dosing
-                  of Cannabidiol on Drowsiness, Testosterone Levels, and Liver Function. Medical Cannabis and Cannabinoids
-                  6(1), 32-40. <a href="https://pubmed.ncbi.nlm.nih.gov/36968131/" target="_blank" style="font-size: 20px;">[link]</a></li>
-<br>
-                  <li>Kube, A. R., Das, S., Fowler, P. J. (2023). Community-and Data-Driven Homelessness Prevention and
-                  Service Delivery: Optimizing for Equity. Journal of the American Medical Informatics Association 30(6),
-                  32-40. <a href="https://www.ncbi.nlm.nih.gov/pmc/articles/PMC10198533/" target="_blank" style="font-size: 20px;">[link]</a></li>
-<br>
-                  <li>Kube, A., Das, S., Fowler, P. J. (2023). Fair and Efficient Allocation of Scarce Resources Based on
-                  Predicted Outcomes: Implications for Homeless Service Delivery. Journal of Artificial Intelligence Research
-                  76, 1219-1244. <a href="https://dl.acm.org/doi/pdf/10.1613/jair.1.12847" target="_blank" style="font-size: 20px;">[pdf]</a></li>
-<br>
-                  <li>Kube, A., Das, S., Fowler, P. J., Vorobeychik, Y. (2022). Just Resource Allocation? How Algorithmic Predictions and Human Notions of Justice Interact. In Proceedings of the 23rd ACM Conference on Economics
-                  and Computation, 1184-1242. <a href="https://par.nsf.gov/servlets/purl/10330929" target="_blank" style="font-size: 20px;">[pdf]</a></li>
-<br>
-                  <li>Cheung, F., Kube, A., Tay, L. et al. (2020). The impact of the Syrian conflict on population well-being.
-                  Nature Communications, 11(1), 1-10. <a href="https://www.nature.com/articles/s41467-020-17369-0" target="_blank" style="font-size: 20px;">[link]</a></li>
-                  <br>
-                  <li>Hill, P. L., Cheung, F., Kube, A., Burrow, A. L. (2019). Life engagement is associated with higher GDP
-                  among societies. Journal of Research in Personality, 78, 210-214. <a href="https://www.sciencedirect.com/science/article/abs/pii/S0092656618303696" target="_blank" style="font-size: 20px;">[link]</a></li>
-                  <br>
-                  <li>Kube, A., Das, S., Fowler, P. J. (2019). Allocating Interventions Based on Predicted Outcomes: A Case
-                  Study on Homelessness Services. Proceedings of the AAAI Conference on Artificial Intelligence, 33(1),
-                  622-629. <a href="https://dl.acm.org/doi/10.1609/aaai.v33i01.3301622" target="_blank" style="font-size: 20px;">[link]</a></li>
-			  <br>
-		  </ul>
-                   </div> 
-		</div>
+            <br />
+            <div class="ContactInfoTextMain CurrentPosition">
+              <b>Assistant Instructional Professor</b>
             </div>
-	    </div>
+            <br />
+            <p><b>akube@uchicago.edu</b><br /></p>
+            <p>
+              Data Science Institute<br />
+              The University of Chicago<br />
+            </p>
+            <a href="https://twitter.com/AmandaRKube" title=""
+              ><img
+                alt="twitter"
+                target="_blank"
+                src="twitter.png"
+                class="SocialIcon"
+            /></a>
 
-    
-     
-</body>
+            <a href="https://www.linkedin.com/in/amanda-kube-488071a8/" title=""
+              ><img
+                alt="linkedin"
+                target="_blank"
+                src="linkedin.png"
+                class="SocialIcon"
+            /></a>
 
+            <a
+              href="https://scholar.google.com/citations?user=eML9qi8AAAAJ&hl=en&inst=2230987035966559800"
+              title=""
+              ><img
+                alt="Google Scholar"
+                target="_blank"
+                src="google-scholar.svg"
+                class="SocialIcon"
+            /></a>
+
+            <a
+              href="https://www.researchgate.net/profile/Amanda_Kube?cp=shp"
+              title=""
+              ><img
+                alt="Follow me on ResearchGate"
+                target="_blank"
+                src="researchgate.svg"
+                class="SocialIcon"
+            /></a>
+
+            <a href="https://orcid.org/0000-0002-4814-3209" title=""
+              ><img
+                alt="orcid"
+                target="_blank"
+                src="orcid.svg"
+                class="SocialIcon"
+            /></a>
+          </div>
+        </div>
+
+        <!-- Page Content -->
+
+        <!-- Entries Column -->
+        <div class="col-md-8" style="height: 50vh">
+          <div
+            style="
+              margin-top: 3%;
+              font-size: 20px;
+              line-height: 1.5;
+              margin-bottom: 3%;
+              margin-right: -65px;
+            "
+          >
+            <h2 id="teaching">Publications</h2>
+            <ul>
+              <li>
+                Kaufmann, R., Harris, Bozer A., Jotte, A. R. K., Aqua, K.,
+                (2023) The Effects of Long-Term Self-Dosing of Cannabidiol on
+                Drowsiness, Testosterone Levels, and Liver Function. Medical
+                Cannabis and Cannabinoids 6(1), 32-40.
+                <a
+                  href="https://pubmed.ncbi.nlm.nih.gov/36968131/"
+                  target="_blank"
+                  style="font-size: 20px"
+                  >[link]</a
+                >
+              </li>
+              <br />
+              <li>
+                Kube, A. R., Das, S., Fowler, P. J. (2023). Community-and
+                Data-Driven Homelessness Prevention and Service Delivery:
+                Optimizing for Equity. Journal of the American Medical
+                Informatics Association 30(6), 32-40.
+                <a
+                  href="https://www.ncbi.nlm.nih.gov/pmc/articles/PMC10198533/"
+                  target="_blank"
+                  style="font-size: 20px"
+                  >[link]</a
+                >
+              </li>
+              <br />
+              <li>
+                Kube, A., Das, S., Fowler, P. J. (2023). Fair and Efficient
+                Allocation of Scarce Resources Based on Predicted Outcomes:
+                Implications for Homeless Service Delivery. Journal of
+                Artificial Intelligence Research 76, 1219-1244.
+                <a
+                  href="https://dl.acm.org/doi/pdf/10.1613/jair.1.12847"
+                  target="_blank"
+                  style="font-size: 20px"
+                  >[pdf]</a
+                >
+              </li>
+              <br />
+              <li>
+                Kube, A., Das, S., Fowler, P. J., Vorobeychik, Y. (2022). Just
+                Resource Allocation? How Algorithmic Predictions and Human
+                Notions of Justice Interact. In Proceedings of the 23rd ACM
+                Conference on Economics and Computation, 1184-1242.
+                <a
+                  href="https://par.nsf.gov/servlets/purl/10330929"
+                  target="_blank"
+                  style="font-size: 20px"
+                  >[pdf]</a
+                >
+              </li>
+              <br />
+              <li>
+                Cheung, F., Kube, A., Tay, L. et al. (2020). The impact of the
+                Syrian conflict on population well-being. Nature Communications,
+                11(1), 1-10.
+                <a
+                  href="https://www.nature.com/articles/s41467-020-17369-0"
+                  target="_blank"
+                  style="font-size: 20px"
+                  >[link]</a
+                >
+              </li>
+              <br />
+              <li>
+                Hill, P. L., Cheung, F., Kube, A., Burrow, A. L. (2019). Life
+                engagement is associated with higher GDP among societies.
+                Journal of Research in Personality, 78, 210-214.
+                <a
+                  href="https://www.sciencedirect.com/science/article/abs/pii/S0092656618303696"
+                  target="_blank"
+                  style="font-size: 20px"
+                  >[link]</a
+                >
+              </li>
+              <br />
+              <li>
+                Kube, A., Das, S., Fowler, P. J. (2019). Allocating
+                Interventions Based on Predicted Outcomes: A Case Study on
+                Homelessness Services. Proceedings of the AAAI Conference on
+                Artificial Intelligence, 33(1), 622-629.
+                <a
+                  href="https://dl.acm.org/doi/10.1609/aaai.v33i01.3301622"
+                  target="_blank"
+                  style="font-size: 20px"
+                  >[link]</a
+                >
+              </li>
+              <br />
+            </ul>
+          </div>
+        </div>
+      </div>
+    </div>
+  </body>
 </html>

--- a/publications.html
+++ b/publications.html
@@ -171,14 +171,13 @@
         <!-- Page Content -->
 
         <!-- Entries Column -->
-        <div class="col-md-8" style="height: 50vh">
+        <div class="col-sm-12 col-md-8 EntriesColumn">
           <div
             style="
               margin-top: 3%;
               font-size: 20px;
               line-height: 1.5;
               margin-bottom: 3%;
-              margin-right: -65px;
             "
           >
             <h2 id="teaching">Publications</h2>

--- a/styles.css
+++ b/styles.css
@@ -5,18 +5,32 @@ html {
 
 .ContactInfoContainer {
   font-size: 16px;
+}
 
-  /* @media (min-width: 480px) {
-    margin-left: -7vh;
-  } */
+.Headshot {
+  width: 280px;
+  height: 225px;
+}
+
+.ContactInfoTextMain {
+  font-family: "Oswald", sans-serif;
+}
+
+.NameAndTitles {
+  font-size: 30px;
+}
+
+.CurrentPosition {
+  font-size: 23px;
 }
 
 .EntriesColumn {
   height: 50vh;
+}
 
-  /* @media (min-width: 480px) {
-    margin-right: -7vh;
-  } */
+.SocialIcon {
+  width: 32px;
+  height: 32px;
 }
 
 .row {

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,27 @@
+html {
+  min-width: 100%;
+  width: 100%;
+}
+
+.ContactInfoContainer {
+  font-size: 16px;
+
+  /* @media (min-width: 480px) {
+    margin-left: -7vh;
+  } */
+}
+
+.EntriesColumn {
+  height: 50vh;
+
+  /* @media (min-width: 480px) {
+    margin-right: -7vh;
+  } */
+}
+
+.row {
+  @media (max-width: 481px) {
+    margin-right: 0;
+    margin-left: 0;
+  }
+}

--- a/teaching.html
+++ b/teaching.html
@@ -6,149 +6,323 @@
 -->
 
 <html lang="en">
-
-<head>
+  <head>
     <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-172221298-1"></script>
+    <script
+      async
+      src="https://www.googletagmanager.com/gtag/js?id=UA-172221298-1"
+    ></script>
     <script>
       window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
+      function gtag() {
+        dataLayer.push(arguments);
+      }
+      gtag("js", new Date());
 
-      gtag('config', 'UA-172221298-1');
+      gtag("config", "UA-172221298-1");
     </script>
 
-    <meta charset="UTF-8">
-    <meta name="author" content="Amanda R. Kube Jotte">
-    <meta name="robots" content="INDEX,FOLLOW">
-    <meta name="keywords" content="Amanda, Kube, Jotte, PhD, Data Science, Computational Social Science">
-    <meta name="description"
-        content="Data Science Preceptor studying applications of AI to Social Sciences and Public Health">
-    <meta content="IE=edge" http-equiv="X-UA-Compatible">
-    <meta content="width=device-width,initial-scale=1" name="viewport">
+    <meta charset="UTF-8" />
+    <meta name="author" content="Amanda R. Kube Jotte" />
+    <meta name="robots" content="INDEX,FOLLOW" />
+    <meta
+      name="keywords"
+      content="Amanda, Kube, Jotte, PhD, Data Science, Computational Social Science"
+    />
+    <meta
+      name="description"
+      content="Data Science Preceptor studying applications of AI to Social Sciences and Public Health"
+    />
+    <meta content="IE=edge" http-equiv="X-UA-Compatible" />
+    <meta content="width=device-width,initial-scale=1" name="viewport" />
     <meta name="google" content="notranslate" />
-    <meta name="google-site-verification" content="leIOIHzfotk4I-5IQ5_YwW-Ubl-t0JqtmYpaa6gzBJg" />
-	
-  <title>Amanda R. Kube Jotte</title>
-  <meta charset="utf-8">
-	<meta name="HandheldFriendly" content="True">
-	<meta name="MobileOptimized" content="320">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link rel="stylesheet" href="bootstrap.min.css">
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.0/jquery.min.js"></script>
-  <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js"></script>
-  <link href='https://fonts.googleapis.com/css?family=Oswald:700' rel='stylesheet' type='text/css'>
-</head>
-<body>
+    <meta
+      name="google-site-verification"
+      content="leIOIHzfotk4I-5IQ5_YwW-Ubl-t0JqtmYpaa6gzBJg"
+    />
 
+    <title>Amanda R. Kube Jotte</title>
+    <meta charset="utf-8" />
+    <meta name="HandheldFriendly" content="True" />
+    <meta name="MobileOptimized" content="320" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="bootstrap.min.css" />
+    <link rel="stylesheet" href="styles.css" />
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.0/jquery.min.js"></script>
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js"></script>
+    <link
+      href="https://fonts.googleapis.com/css?family=Oswald:700"
+      rel="stylesheet"
+      type="text/css"
+    />
+  </head>
+  <body>
+    <!-- Navigation -->
+    <nav class="navbar navbar-inverse navbar-static-top" role="navigation">
+      <div class="container">
+        <div class="navbar-header">
+          <button
+            type="button"
+            class="navbar-toggle collapsed"
+            data-toggle="collapse"
+            data-target="#bs-example-navbar-collapse-1"
+          >
+            <span class="sr-only">Toggle navigation</span>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+          </button>
+        </div>
 
-<!-- Navigation -->
-	<nav class="navbar navbar-inverse navbar-static-top" role="navigation">
-	  <div class="container">
-		<div class="navbar-header">
-		  <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#bs-example-navbar-collapse-1">
-						<span class="sr-only">Toggle navigation</span>
-						<span class="icon-bar"></span>
-						<span class="icon-bar"></span>
-						<span class="icon-bar"></span>
-					</button>
-		</div>
+        <!-- Collect the nav links, forms, and other content for toggling -->
+        <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
+          <ul class="nav navbar-nav">
+            <li><a href="index.html" style="font-size: 20px">Home</a></li>
+            <li>
+              <a href="teaching.html" style="font-size: 20px">Teaching</a>
+            </li>
+            <li>
+              <a href="publications.html" style="font-size: 20px"
+                >Publications</a
+              >
+            </li>
+            <li>
+              <a
+                href="Amanda_Kube_CV_111423.pdf"
+                target="_blank"
+                style="font-size: 20px"
+                >CV</a
+              >
+            </li>
+          </ul>
+        </div>
+      </div>
+    </nav>
 
-		<!-- Collect the nav links, forms, and other content for toggling -->
-		<div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
-		  <ul class="nav navbar-nav">
-				  <li><a href="index.html" style="font-size: 20px;">Home</a></li>
-			  	<li><a href="teaching.html" style="font-size: 20px;">Teaching</a></li>
-			  	<li><a href="publications.html" style="font-size: 20px;">Publications</a></li>
-				  <li><a href="Amanda_Kube_CV_111423.pdf" target="_blank" style="font-size: 20px;">CV</a></li> 
-		  </ul>
-		</div>
-	  </div>
-	</nav>
-  
     <div class="container">
-
-        <div class="row">
-            <!-- Contact Info on the Sidebar -->
-            <div class="col-md-4">
-		    <div style="font-size:16px; margin-left:-60px"">
-                <img class="img-responsive" src="headshot_jotte.jpg" alt="image of me" style="width:280px;height:225px;"><br>
-                <div style="font-family: 'Oswald', sans-serif; font-size: 30px;"><b>Amanda R. Kube Jotte, M.S., Ph.D.</b></div><br>
-		<div style="font-family: 'Oswald', sans-serif; font-size: 23px;"><b>Assistant Instructional Professor</b></div><br>
-                <p><b>akube@uchicago.edu</b><br>
-                <p>Data Science Institute<br>
-                The University of Chicago<br>
-                </p>
-			    <a href="https://twitter.com/AmandaRKube"
-                                        title=""><img alt="twitter" target="_blank"
-                                            src="twitter.png" style="width:32px;height:32px;"></a>
-		   
-		    <a href="https://www.linkedin.com/in/amanda-kube-488071a8/"
-                                        title=""><img alt="linkedin" target="_blank"
-                                            src="linkedin.png" style="width:32px;height:32px;"></a>
-					
-		    <a href="https://scholar.google.com/citations?user=eML9qi8AAAAJ&hl=en&inst=2230987035966559800"
-                                        title=""><img alt="Google Scholar" target="_blank"
-                                            src="google-scholar.svg" style="width:32px;height:32px;"></a>
-					
-		    <a href="https://www.researchgate.net/profile/Amanda_Kube?cp=shp"
-                                        title=""><img alt="Follow me on ResearchGate" target="_blank"
-                                            src="researchgate.svg" style="width:32px;height:32px;"></a>
-					
-		    <a href="https://orcid.org/0000-0002-4814-3209"
-                                        title=""><img alt="orcid" target="_blank"
-							   src="orcid.svg" style="width:32px;height:32px;"></a>
+      <div class="row">
+        <!-- Contact Info on the Sidebar -->
+        <div class="col-sm-12 col-md-4">
+          <div class="ContactInfoContainer">
+            <img
+              class="img-responsive Headshot"
+              src="headshot_jotte.jpg"
+              alt="image of me"
+            /><br />
+            <div class="ContactInfoTextMain NameAndTitles">
+              <b>Amanda R. Kube Jotte, M.S., Ph.D.</b>
             </div>
-		    </div>
-	
-	<!-- Page Content -->
-
-
-            <!-- Entries Column -->
-            <div class="col-md-8" style="height: 50vh;">
-                
-                <div style="margin-top:3%; font-size:20px; line-height:1.5; margin-right:-120px"> 
-                  
-                  <h2 id="teaching">Teaching Experience</h2>
-
-			<ul>
-	<li><em>University of Chicago</em><br>
-		DATA 119 Introduction to Data Science II
-		<ul>
-			<li>Winter 2024 (<a href="Data_119_Syllabus_Winter_24.pdf" target="_blank" style="font-size: 20px;">Syllabus Sect 2 & 3</a>, Student Evaluations <a href="DATA119_Win24_2_eval.pdf" target="_blank" style="font-size: 20px;">Sect 2</a> & <a href="DATA119_Win24_3_eval.pdf" target="_blank" style="font-size: 20px;">Sect 3</a>)</li>
-		</ul>	
-		DATA 118 Introduction to Data Science I
-          	<ul>
-			<li>Autumn 2023 (Syllabus <a href="Data_118_Syllabus_Autumn_23_Section_2.pdf" target="_blank" style="font-size: 20px;">Section 2</a> & <a href="Data_118_Syllabus_Autumn_23_Section_3.pdf" target="_blank" style="font-size: 20px;">Section 3</a>, Student Evaluations <a href="DATA118_Aut23_2_eval.pdf" target="_blank" style="font-size: 20px;">Sect 2</a> & <a href="DATA118_Aut23_3_eval.pdf" target="_blank" style="font-size: 20px;">Sect 3</a>)</li>
-			<li>Winter 2023 (<a href="Data_118_Syllabus.pdf" target="_blank" style="font-size: 20px;">Syllabus</a>, <a href=<a href="DATA118_Win23_2_eval.pdf" target="_blank" style="font-size: 20px;">Student Evaluations</a>)</li>
-		</ul>
-	  </li>
-<br>
-        <li><em>Harry S. Truman College</em><br>
-		CIS 299 Special Topics in Computer and Information Sciences: Introduction to Data Science II
-			<ul><li>Spring 2024 (<a href="CIS299_Spring2024_AmandaKube.pdf" target="_blank" style="font-size: 20px;">Syllabus</a>)</li></ul>
-		CIS 299 Special Topics in Computer and Information Sciences: Introduction to Data Science I
-			<ul><li>Spring 2023 (<a href="CIS299_Spring2023_AmandaKube.pdf" target="_blank" style="font-size: 20px;">Syllabus</a>)</li></ul>
-        </li>
-<br>
-
-          <li><em>Washington University in St. Louis</em><br>
-		  DCDS 510 Data Wrangling
-			<ul><li>Spring 2021 (<a href="DCDS_510_Syllabus.pdf" target="_blank" style="font-size: 20px;">Syllabus</a>)</li></ul>
-		  DCDS 499 Introduction to Graduate Research in Computational and Data Sciences
-		  	<ul><li>Fall 2020 (<a href="CDS_Seminar_1_Syllabus.pdf" target="_blank" style="font-size: 20px;">Syllabus</a>)</li></ul>
-          			
-			</ul>
-
-        <h2 id="tsp">Teaching Philosophy</h2>
-        <a href="TSP.pdf" target="_blank" style="font-size: 20px;">Click here</a> to read my teaching and service philosophy
-		               </div> 
-		</div>
+            <br />
+            <div class="ContactInfoTextMain CurrentPosition">
+              <b>Assistant Instructional Professor</b>
             </div>
-	    </div>
+            <br />
+            <p><b>akube@uchicago.edu</b><br /></p>
+            <p>
+              Data Science Institute<br />
+              The University of Chicago<br />
+            </p>
+            <a href="https://twitter.com/AmandaRKube" title=""
+              ><img
+                alt="twitter"
+                target="_blank"
+                src="twitter.png"
+                class="SocialIcon"
+            /></a>
 
-    
-     
-</body>
+            <a href="https://www.linkedin.com/in/amanda-kube-488071a8/" title=""
+              ><img
+                alt="linkedin"
+                target="_blank"
+                src="linkedin.png"
+                class="SocialIcon"
+            /></a>
 
+            <a
+              href="https://scholar.google.com/citations?user=eML9qi8AAAAJ&hl=en&inst=2230987035966559800"
+              title=""
+              ><img
+                alt="Google Scholar"
+                target="_blank"
+                src="google-scholar.svg"
+                class="SocialIcon"
+            /></a>
+
+            <a
+              href="https://www.researchgate.net/profile/Amanda_Kube?cp=shp"
+              title=""
+              ><img
+                alt="Follow me on ResearchGate"
+                target="_blank"
+                src="researchgate.svg"
+                class="SocialIcon"
+            /></a>
+
+            <a href="https://orcid.org/0000-0002-4814-3209" title=""
+              ><img
+                alt="orcid"
+                target="_blank"
+                src="orcid.svg"
+                class="SocialIcon"
+            /></a>
+          </div>
+        </div>
+
+        <!-- Page Content -->
+
+        <!-- Entries Column -->
+        <div class="col-md-8" style="height: 50vh">
+          <div
+            style="
+              margin-top: 3%;
+              font-size: 20px;
+              line-height: 1.5;
+              margin-right: -120px;
+            "
+          >
+            <h2 id="teaching">Teaching Experience</h2>
+
+            <ul>
+              <li>
+                <em>University of Chicago</em><br />
+                DATA 119 Introduction to Data Science II
+                <ul>
+                  <li>
+                    Winter 2024 (<a
+                      href="Data_119_Syllabus_Winter_24.pdf"
+                      target="_blank"
+                      style="font-size: 20px"
+                      >Syllabus Sect 2 & 3</a
+                    >, Student Evaluations
+                    <a
+                      href="DATA119_Win24_2_eval.pdf"
+                      target="_blank"
+                      style="font-size: 20px"
+                      >Sect 2</a
+                    >
+                    &
+                    <a
+                      href="DATA119_Win24_3_eval.pdf"
+                      target="_blank"
+                      style="font-size: 20px"
+                      >Sect 3</a
+                    >)
+                  </li>
+                </ul>
+                DATA 118 Introduction to Data Science I
+                <ul>
+                  <li>
+                    Autumn 2023 (Syllabus
+                    <a
+                      href="Data_118_Syllabus_Autumn_23_Section_2.pdf"
+                      target="_blank"
+                      style="font-size: 20px"
+                      >Section 2</a
+                    >
+                    &
+                    <a
+                      href="Data_118_Syllabus_Autumn_23_Section_3.pdf"
+                      target="_blank"
+                      style="font-size: 20px"
+                      >Section 3</a
+                    >, Student Evaluations
+                    <a
+                      href="DATA118_Aut23_2_eval.pdf"
+                      target="_blank"
+                      style="font-size: 20px"
+                      >Sect 2</a
+                    >
+                    &
+                    <a
+                      href="DATA118_Aut23_3_eval.pdf"
+                      target="_blank"
+                      style="font-size: 20px"
+                      >Sect 3</a
+                    >)
+                  </li>
+                  <li>
+                    Winter 2023 (<a
+                      href="Data_118_Syllabus.pdf"
+                      target="_blank"
+                      style="font-size: 20px"
+                      >Syllabus</a
+                    >,
+                    <a
+                      href="<a"
+                      href="DATA118_Win23_2_eval.pdf"
+                      target="_blank"
+                      style="font-size: 20px"
+                      >Student Evaluations</a
+                    >)
+                  </li>
+                </ul>
+              </li>
+              <br />
+              <li>
+                <em>Harry S. Truman College</em><br />
+                CIS 299 Special Topics in Computer and Information Sciences:
+                Introduction to Data Science II
+                <ul>
+                  <li>
+                    Spring 2024 (<a
+                      href="CIS299_Spring2024_AmandaKube.pdf"
+                      target="_blank"
+                      style="font-size: 20px"
+                      >Syllabus</a
+                    >)
+                  </li>
+                </ul>
+                CIS 299 Special Topics in Computer and Information Sciences:
+                Introduction to Data Science I
+                <ul>
+                  <li>
+                    Spring 2023 (<a
+                      href="CIS299_Spring2023_AmandaKube.pdf"
+                      target="_blank"
+                      style="font-size: 20px"
+                      >Syllabus</a
+                    >)
+                  </li>
+                </ul>
+              </li>
+              <br />
+
+              <li>
+                <em>Washington University in St. Louis</em><br />
+                DCDS 510 Data Wrangling
+                <ul>
+                  <li>
+                    Spring 2021 (<a
+                      href="DCDS_510_Syllabus.pdf"
+                      target="_blank"
+                      style="font-size: 20px"
+                      >Syllabus</a
+                    >)
+                  </li>
+                </ul>
+                DCDS 499 Introduction to Graduate Research in Computational and
+                Data Sciences
+                <ul>
+                  <li>
+                    Fall 2020 (<a
+                      href="CDS_Seminar_1_Syllabus.pdf"
+                      target="_blank"
+                      style="font-size: 20px"
+                      >Syllabus</a
+                    >)
+                  </li>
+                </ul>
+              </li>
+            </ul>
+
+            <h2 id="tsp">Teaching Philosophy</h2>
+            <a href="TSP.pdf" target="_blank" style="font-size: 20px"
+              >Click here</a
+            >
+            to read my teaching and service philosophy
+          </div>
+        </div>
+      </div>
+    </div>
+  </body>
 </html>

--- a/teaching.html
+++ b/teaching.html
@@ -171,15 +171,8 @@
         <!-- Page Content -->
 
         <!-- Entries Column -->
-        <div class="col-md-8" style="height: 50vh">
-          <div
-            style="
-              margin-top: 3%;
-              font-size: 20px;
-              line-height: 1.5;
-              margin-right: -120px;
-            "
-          >
+        <div class="col-sm-12 col-md-8 EntriesColumn">
+          <div style="margin-top: 3%; font-size: 20px; line-height: 1.5">
             <h2 id="teaching">Teaching Experience</h2>
 
             <ul>
@@ -248,7 +241,6 @@
                       >Syllabus</a
                     >,
                     <a
-                      href="<a"
                       href="DATA118_Win23_2_eval.pdf"
                       target="_blank"
                       style="font-size: 20px"


### PR DESCRIPTION
Updates some styles to make sections more responsive on mobile sizes, and pulls some common css into a dedicated .css file. Most of the issues were just coming from how some of the negative margins were behaving on mobile, so updating to user more of the bootstrap responsive grid made things flow a little smoother.

There's some spacing that got updated here without the negative margins, most notably the gutters on the publications and teaching pages and the spacing for the Contact info now has the "PHD" part wrap to another line on desktop, but I think if we updated the container to make it wider it would get back to 1 line.

Also my vscode autoformatter ran automatically, so that's why it looks like so many lines got updated 😬 

<img width="1680" alt="Screenshot 2024-04-20 at 7 16 52 PM" src="https://github.com/amandakube/amandakube.github.io/assets/20304916/25f71697-0e13-478c-b18b-4f82b382960d">
<img width="408" alt="Screen Shot 2024-04-20 at 6 15 19 PM" src="https://github.com/amandakube/amandakube.github.io/assets/20304916/e4f1f4cb-409e-4cf8-bdef-f18ec443fdd6">
<img width="398" alt="Screen Shot 2024-04-20 at 6 15 30 PM" src="https://github.com/amandakube/amandakube.github.io/assets/20304916/27d83476-9168-4c7f-bc02-456395540786">
<img width="389" alt="Screen Shot 2024-04-20 at 6 15 39 PM" src="https://github.com/amandakube/amandakube.github.io/assets/20304916/4e8b44b5-bd26-453a-a460-ae1fad064614">
<img width="1680" alt="Screen Shot 2024-04-20 at 6 15 48 PM" src="https://github.com/amandakube/amandakube.github.io/assets/20304916/1fb5551f-3421-4149-b1b1-4f03aa0f1f05">
<img width="1678" alt="Screen Shot 2024-04-20 at 6 15 55 PM" src="https://github.com/amandakube/amandakube.github.io/assets/20304916/c1ccef92-e324-4dde-be05-5832601dcf1a">
